### PR TITLE
Add more authentication methods

### DIFF
--- a/ext/libssh_ruby/channel.c
+++ b/ext/libssh_ruby/channel.c
@@ -21,7 +21,7 @@ typedef struct ChannelHolderStruct ChannelHolder;
 
 static const rb_data_type_t channel_type = {
     "ssh_channel",
-    {channel_mark, channel_free, channel_memsize, {NULL, NULL}},
+    {channel_mark, channel_free, channel_memsize,},
     NULL,
     NULL,
     RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,

--- a/ext/libssh_ruby/extconf.rb
+++ b/ext/libssh_ruby/extconf.rb
@@ -12,9 +12,9 @@ end
 unless have_library('ssh')
   abort 'Cannot find libssh'
 end
-unless have_library('ssh_threads')
-  abort 'Cannot find libssh_threads'
-end
+
+# libssh 0.8 has merged libssh_threads into libssh, so it’s not required.
+have_library('ssh_threads')
 
 have_const('SSH_KEYTYPE_ED25519', 'libssh/libssh.h')
 

--- a/ext/libssh_ruby/extconf.rb
+++ b/ext/libssh_ruby/extconf.rb
@@ -3,7 +3,7 @@ require 'mkmf'
 if ENV['LIBSSH_CFLAGS']
   $CFLAGS = ENV['LIBSSH_CFLAGS']
 else
-  $CFLAGS << ' -Wall -W'
+  $CFLAGS << ' -Wall -W -Wno-deprecated-declarations -Wno-missing-field-initializers'
 end
 
 unless have_header('libssh/libssh.h')

--- a/ext/libssh_ruby/key.c
+++ b/ext/libssh_ruby/key.c
@@ -6,8 +6,11 @@ static void key_free(void *);
 static size_t key_memsize(const void *);
 
 static const rb_data_type_t key_type = {
-    "ssh_key", {NULL, key_free, key_memsize, {NULL, NULL}},           NULL,
-    NULL,      RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,
+    "ssh_key",
+    {NULL, key_free, key_memsize,},
+    NULL,
+    NULL,
+    RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 static VALUE key_alloc(VALUE klass) {

--- a/ext/libssh_ruby/libssh_ruby.c
+++ b/ext/libssh_ruby/libssh_ruby.c
@@ -79,5 +79,6 @@ void Init_libssh_ruby(void) {
   Init_libssh_channel();
   Init_libssh_error();
   Init_libssh_key();
+  Init_libssh_pki();
   Init_libssh_scp();
 }

--- a/ext/libssh_ruby/libssh_ruby.c
+++ b/ext/libssh_ruby/libssh_ruby.c
@@ -55,6 +55,8 @@ void Init_libssh_ruby(void) {
   rb_define_const(rb_mLibSSH, "AUTH_SUCCESS", INT2FIX(SSH_AUTH_SUCCESS));
   /* Return value that indicates EAGAIN in nonblocking mode. */
   rb_define_const(rb_mLibSSH, "AUTH_AGAIN", INT2FIX(SSH_AUTH_AGAIN));
+  /* Returned by ssh_userauth_kbdint when the server asks questions. */
+  rb_define_const(rb_mLibSSH, "AUTH_INFO", INT2FIX(SSH_AUTH_INFO));
 
   /* Major version defined in header. */
   rb_define_const(rb_mLibSSH, "LIBSSH_VERSION_MAJOR",

--- a/ext/libssh_ruby/libssh_ruby.h
+++ b/ext/libssh_ruby/libssh_ruby.h
@@ -15,6 +15,7 @@ void Init_libssh_session(void);
 void Init_libssh_channel(void);
 void Init_libssh_error(void);
 void Init_libssh_key(void);
+void Init_libssh_pki(void);
 void Init_libssh_scp(void);
 
 void libssh_ruby_raise(ssh_session session);

--- a/ext/libssh_ruby/scp.c
+++ b/ext/libssh_ruby/scp.c
@@ -20,8 +20,11 @@ struct ScpHolderStruct {
 typedef struct ScpHolderStruct ScpHolder;
 
 static const rb_data_type_t scp_type = {
-    "ssh_scp", {scp_mark, scp_free, scp_memsize, {NULL, NULL}},       NULL,
-    NULL,      RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,
+    "ssh_scp",
+    {scp_mark, scp_free, scp_memsize},
+    NULL,
+    NULL,
+    RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 static VALUE scp_alloc(VALUE klass) {

--- a/ext/libssh_ruby/session.c
+++ b/ext/libssh_ruby/session.c
@@ -639,6 +639,46 @@ static VALUE m_userauth_publickey_auto(VALUE self) {
 }
 
 /*
+ * @overload userauth_kbdint
+ *  Try to authenticate through the "keyboard-interactive" method.
+ *  @return [Fixnum]
+ *  @see http://api.libssh.org/stable/group__libssh__session.html ssh_userauth_kbdint
+ */
+static VALUE m_userauth_kbdint(VALUE self) {
+  SessionHolder *holder = libssh_ruby_session_holder(self);
+  int rc = ssh_userauth_kbdint(holder->session, NULL, NULL);
+  RAISE_IF_ERROR(rc);
+  return INT2FIX(rc);
+}
+
+/*
+ * @overload userauth_kbdint_getnprompts
+ *  Get the number of prompts (questions) the server has given.
+ *  @return [Fixnum]
+ *  @see http://api.libssh.org/stable/group__libssh__session.html ssh_userauth_kbdint_getnprompts
+ */
+static VALUE m_userauth_kbdint_getnpromts(VALUE self) {
+  SessionHolder *holder = libssh_ruby_session_holder(self);
+  int n = ssh_userauth_kbdint_getnprompts(holder->session);
+  return INT2FIX(n);
+}
+
+/*
+ * @overload userauth_kbdint_setanswer(i, answer)
+ *  Set the answer to a prompt.
+ *  @param [Fixnum] i Index of the prompt to answer.
+ *  @param [String] answer
+ *  @return [Fixnum]
+ *  @see http://api.libssh.org/stable/group__libssh__session.html ssh_userauth_kbdint_setanswer
+ */
+static VALUE m_userauth_kbdint_setanswer(VALUE self, VALUE i, VALUE answer) {
+  SessionHolder *holder = libssh_ruby_session_holder(self);
+  int rc = ssh_userauth_kbdint_setanswer(holder->session, FIX2INT(i), StringValueCStr(answer));
+  RAISE_IF_ERROR(rc);
+  return Qnil;
+}
+
+/*
  * @overload get_publickey
  *  Get the server public key from a session.
  *  @return [Key]
@@ -756,6 +796,12 @@ void Init_libssh_session() {
                    RUBY_METHOD_FUNC(m_userauth_publickey), 1);
   rb_define_method(rb_cLibSSHSession, "userauth_publickey_auto",
                    RUBY_METHOD_FUNC(m_userauth_publickey_auto), 0);
+  rb_define_method(rb_cLibSSHSession, "userauth_kbdint",
+                   RUBY_METHOD_FUNC(m_userauth_kbdint), 0);
+  rb_define_method(rb_cLibSSHSession, "userauth_kbdint_getnprompts",
+                   RUBY_METHOD_FUNC(m_userauth_kbdint_getnpromts), 0);
+  rb_define_method(rb_cLibSSHSession, "userauth_kbdint_setanswer",
+                   RUBY_METHOD_FUNC(m_userauth_kbdint_setanswer), 2);
   rb_define_method(rb_cLibSSHSession, "get_publickey",
                    RUBY_METHOD_FUNC(m_get_publickey), 0);
   rb_define_method(rb_cLibSSHSession, "write_knownhost",

--- a/ext/libssh_ruby/session.c
+++ b/ext/libssh_ruby/session.c
@@ -16,7 +16,7 @@ static size_t session_memsize(const void *);
 
 const rb_data_type_t session_type = {
     "ssh_session",
-    {session_mark, session_free, session_memsize, {NULL, NULL}},
+    {session_mark, session_free, session_memsize,},
     NULL,
     NULL,
     RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY,

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.7
+FROM ubuntu:latest
 
-RUN apk add openssh --no-cache
+RUN apt-get update && apt-get install -y openssh-server
 
-RUN adduser -D alice && (echo alice:alice | chpasswd)
+RUN useradd -m alice && (echo alice:alice | chpasswd)
 COPY id_ecdsa id_ecdsa.pub id_ed25519 id_ed25519.pub /home/alice/.ssh/
 RUN cat /home/alice/.ssh/id_ecdsa.pub /home/alice/.ssh/id_ed25519.pub > /home/alice/.ssh/authorized_keys
 COPY ssh_host_ecdsa_key ssh_host_ecdsa_key.pub ssh_host_ed25519_key ssh_host_ed25519_key.pub /etc/ssh/
@@ -14,4 +14,4 @@ RUN chmod 600 /home/alice/.ssh/* \
 COPY sshd_config /etc/ssh/sshd_config
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D", "-e"]
+CMD ["service", "ssh", "start", "-D", "-e"]

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:latest
+FROM archlinux:latest
 
-RUN apt-get update && apt-get install -y openssh-server
+RUN pacman -Sy --noconfirm openssh
 
 RUN useradd -m alice && (echo alice:alice | chpasswd)
 COPY id_ecdsa id_ecdsa.pub id_ed25519 id_ed25519.pub /home/alice/.ssh/
@@ -14,4 +14,4 @@ RUN chmod 600 /home/alice/.ssh/* \
 COPY sshd_config /etc/ssh/sshd_config
 
 EXPOSE 22
-CMD ["service", "ssh", "start", "-D", "-e"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe LibSSH::Session do
       session.host = SshHelper.host
       session.port = DockerHelper.port
       session.user = SshHelper.user
-      session.connect
     end
 
     context 'without valid private key' do
       it 'is denied' do
+        session.connect
         expect(session.userauth_publickey_auto).to eq(LibSSH::AUTH_DENIED)
       end
     end
@@ -82,6 +82,7 @@ RSpec.describe LibSSH::Session do
       end
 
       it 'returns available methods' do
+        session.connect
         expect(session.userauth_publickey_auto).to eq(LibSSH::AUTH_SUCCESS)
       end
     end

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe LibSSH::Session do
     end
   end
 
+  describe '#userauth_publickey' do
+    before do
+      session.host = SshHelper.host
+      session.port = DockerHelper.port
+      session.user = SshHelper.user
+      session.connect
+    end
+
+    it 'accepts good keys' do
+      identity = SshHelper.identity_path
+      privkey = LibSSH::PKI.import_privkey_base64(File.read(identity))
+      expect(session.userauth_publickey(privkey)).to eq(LibSSH::AUTH_SUCCESS)
+    end
+  end
+
   describe '#userauth_publickey_auto' do
     before do
       session.host = SshHelper.host

--- a/spec/sshd_config
+++ b/spec/sshd_config
@@ -1,7 +1,7 @@
 AuthorizedKeysFile .ssh/authorized_keys
 
 UsePAM yes
-ChallengeResponseAuthentication no
+KbdInteractiveAuthentication yes
 PasswordAuthentication yes
 PermitEmptyPasswords no
 PermitRootLogin no

--- a/spec/sshd_config
+++ b/spec/sshd_config
@@ -1,5 +1,6 @@
 AuthorizedKeysFile .ssh/authorized_keys
 
+UsePAM yes
 ChallengeResponseAuthentication no
 PasswordAuthentication yes
 PermitEmptyPasswords no


### PR DESCRIPTION
This introduces a minimal set of methods for authenticating with a private key loaded in memory rather than using a key file, and also for keyboard-interactive authentication.

I have also made the test suite run without failure, and added support for the newer libssh versions.