### PR TITLE
Generate better error messages on invalid options

### DIFF
--- a/ext/libssh_ruby/error.c
+++ b/ext/libssh_ruby/error.c
@@ -24,13 +24,15 @@ void Init_libssh_error(void) {
 }
 
 void libssh_ruby_raise(ssh_session session) {
-  VALUE exc, code, message;
+  VALUE exc, code;
   VALUE argv[1];
 
-  code = INT2FIX(ssh_get_error_code(session));
-  message = rb_str_new_cstr(ssh_get_error(session));
-  argv[0] = message;
+  /* Empty messages are converted to nil so that #to_s defaults to the error type. */
+  const char* message = ssh_get_error(session);
+  argv[0] = (message != NULL && message[0] != '\0') ? rb_str_new_cstr(message) : Qnil;
+
   exc = rb_class_new_instance(1, argv, rb_eLibSSHError);
+  code = INT2FIX(ssh_get_error_code(session));
   rb_ivar_set(exc, id_code, code);
 
   rb_exc_raise(exc);

--- a/ext/libssh_ruby/session.c
+++ b/ext/libssh_ruby/session.c
@@ -99,19 +99,12 @@ static VALUE m_set_log_verbosity(VALUE self, VALUE verbosity) {
   return Qnil;
 }
 
-static VALUE set_option_value(VALUE self, enum ssh_options_e type, const void* value) {
+static VALUE set_string_option(VALUE self, enum ssh_options_e type, VALUE str) {
   SessionHolder *holder;
   TypedData_Get_Struct(self, SessionHolder, &session_type, holder);
+  const void* value = NIL_P(str) ? NULL : StringValueCStr(str);
   RAISE_IF_ERROR(ssh_options_set(holder->session, type, value));
   return Qnil;
-}
-
-static VALUE set_string_option(VALUE self, enum ssh_options_e type, VALUE str) {
-  return set_option_value(self, type, StringValueCStr(str));
-}
-
-static VALUE set_nullable_string_option(VALUE self, enum ssh_options_e type, VALUE str) {
-  return set_option_value(self, type, NIL_P(str) ? NULL : StringValueCStr(str));
 }
 
 /*
@@ -134,7 +127,7 @@ static VALUE m_set_host(VALUE self, VALUE host) {
  *  @see http://api.libssh.org/stable/group__libssh__session.html ssh_options_set(SSH_OPTIONS_USER)
  */
 static VALUE m_set_user(VALUE self, VALUE user) {
-  return set_nullable_string_option(self, SSH_OPTIONS_USER, user);
+  return set_string_option(self, SSH_OPTIONS_USER, user);
 }
 
 static VALUE set_int_option(VALUE self, enum ssh_options_e type, VALUE i) {
@@ -181,7 +174,7 @@ static VALUE m_set_bindaddr(VALUE self, VALUE addr) {
  *  @see http://api.libssh.org/stable/group__libssh__session.html ssh_options_set(SSH_OPTIONS_KNOWNHOSTS)
  */
 static VALUE m_set_knownhosts(VALUE self, VALUE path) {
-  return set_nullable_string_option(self, SSH_OPTIONS_KNOWNHOSTS, path);
+  return set_string_option(self, SSH_OPTIONS_KNOWNHOSTS, path);
 }
 
 static VALUE set_long_option(VALUE self, enum ssh_options_e type, VALUE i) {

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe LibSSH::Session do
 
   describe '#host=' do
     it 'raises error on bad host' do
-      expect { session.host = "foo_bar" }.to raise_error 'LibSSH::Error'
+      expect { session.host = nil }.to raise_error ArgumentError, 'Invalid host: nil'
+      expect { session.host = "foo_bar" }.to raise_error ArgumentError, 'Invalid host: "foo_bar"'
     end
   end
 

--- a/spec/integration/session_spec.rb
+++ b/spec/integration/session_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe LibSSH::Session do
     end
   end
 
+  describe '#host=' do
+    it 'raises error on bad host' do
+      expect { session.host = "foo_bar" }.to raise_error 'LibSSH::Error'
+    end
+  end
+
   describe '#knownhosts' do
     it 'is nullable' do
       session.knownhosts = nil


### PR DESCRIPTION
Currently, Session#host= generates an error whose #to_s is the empty string. The first commit turns the empty message into nil so that the error is at the very least displayed as `LibSSH::Error`.

I went further in the case of invalid options to get messages like `Invalid host: "foobar"` instead of libssh’s `Invalid argument in ssh_options_set`.

See the individual commits for more details.